### PR TITLE
Updated SecretsEncryptionConfig - custom_config is not required

### DIFF
--- a/schemas/cluster.yml.json
+++ b/schemas/cluster.yml.json
@@ -4456,7 +4456,7 @@
     },
     "SecretsEncryptionConfig": {
       "required": [
-        "custom_config"
+        "enabled"
       ],
       "properties": {
         "enabled": {


### PR DESCRIPTION
in `services.kube-api.secrets_encryption_config`, `custom_config` is not required:

If you enable `secrets_encryption_config` but leave `custom_config` blank, Rancher will manage encryption at rest for you.

[RKE Encrypting Secrets at Rest](https://rancher.com/docs/rke/latest/en/config-options/secrets-encryption/)